### PR TITLE
fixed bug in pose

### DIFF
--- a/cram_semantic_map_utils/src/semantic-map.lisp
+++ b/cram_semantic_map_utils/src/semantic-map.lisp
@@ -203,7 +203,7 @@
                   :owl-name owlname
                   :urdf-link-name (urdf-name owlname)
                   :pose (if (= (length ?pose) 7)
-                            (destructuring-bind (x y z q1 q2 q3 w)
+                            (destructuring-bind (x y z w q1 q2 q3)
                                 ?pose
                              (cl-transforms:make-pose
                               (cl-transforms:make-3d-vector x y z)


### PR DESCRIPTION
json_prolog stores quaternion as w x y z, we have to consider this structure when storing inside the cram semantic map